### PR TITLE
fix:(ansible) update model download logic

### DIFF
--- a/edge_auto_launch/launch/component/lidar_centerpoint.launch.xml
+++ b/edge_auto_launch/launch/component/lidar_centerpoint.launch.xml
@@ -2,7 +2,7 @@
   <arg name="input/pointcloud" default="input/pointcloud"/>
   <arg name="output/objects" default="output/objects"/>
   <arg name="model_name" default="centerpoint_tiny" description="options: `centerpoint` or `centerpoint_tiny`"/>
-  <arg name="model_path" default="$(find-pkg-share lidar_centerpoint)/data"/>
+  <arg name="model_path" default="/opt/autoware/data/lidar_centerpoint/"/>
   <arg name="model_param_path" default="$(find-pkg-share edge_auto_launch)/config/$(var model_name).param.yaml"/>
   <arg name="class_remapper_param_path" default="$(find-pkg-share edge_auto_launch)/config/detection_class_remapper.param.yaml"/>
   <arg name="score_threshold" default="0.35"/>


### PR DESCRIPTION
## PR Type
- Bug Fix

## Related Links
- https://github.com/autowarefoundation/autoware.universe/issues/3137
- https://github.com/tier4/edge-auto/pull/17
- https://github.com/tier4/edge-auto-jetson/pull/41
- https://github.com/tier4/edge_auto_jetson_launch/pull/10

## Description

This PR fixes edge-auto to align with Autoware Universe's new model download logic.

## Tests performed

Centerpoint and YOLOX from edge-auto and edge-auto-jetson respectively, were launched, and I confirmed that they were outputting predictions at the correct frequency (~10 Hz).

## Effects on system behavior

Previously, edge-auto's model downloading was broken by an update to Autoware Universe, such that YOLOX and Centerpoint would not be able to launch. This PR updates edge-auto to correctly download models under Autoware Universe's new scheme.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
