### PR TITLE
refactor(shape_estimation): add package name prefix of autoware_

### DIFF
--- a/edge_auto_launch/launch/perception_xt32_sample.launch.xml
+++ b/edge_auto_launch/launch/perception_xt32_sample.launch.xml
@@ -55,7 +55,7 @@
           <arg name="input/pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
           <arg name="output/objects" value="clusters"/>
         </include>
-        <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+        <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
           <arg name="input/objects" value="clusters"/>
           <arg name="output/objects" value="objects_with_feature"/>
           <arg name="node_name" value="shape_estimation"/>
@@ -78,7 +78,7 @@
         <arg name="input/rois1" value="/perception/object_recognition/detection/rois1"/>
         <arg name="input/camera_info1" value="/sensing/camera/camera1/camera_info"/>
       </include>
-      <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+      <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="clusters"/>
         <arg name="output/objects" value="objects_with_feature"/>
         <arg name="node_name" value="shape_estimation"/>

--- a/edge_auto_launch/package.xml
+++ b/edge_auto_launch/package.xml
@@ -21,7 +21,7 @@
   <exec_depend>lidar_centerpoint</exec_depend>
   <exec_depend>nebula_sensor_driver</exec_depend>
   <exec_depend>rviz2</exec_depend>
-  <exec_depend>shape_estimation</exec_depend>
+  <exec_depend>autoware_shape_estimation</exec_depend>
   <exec_depend>vehicle_info_util</exec_depend>
   <exec_depend>image_transport_decompressor</exec_depend>
   <exec_depend>individual_params</exec_depend>


### PR DESCRIPTION
## Description
This PR adds the autoware_ prefix to the package name.

Changes are as following.
1. Folder name (appears as file renaming)
2. Package names in `CMakeLists.txt`, `package.xml`
3. `README.md`
4. Launch files `$(find-pkg-share ...)`
5. `.github/CODEOWNERS`

This PR do not contains any logic change.

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569
Related to https://github.com/autowarefoundation/autoware.universe/pull/7999
## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.