### PR TITLE
refactor(euclidean_cluster): add package name prefix of autoware_

### DIFF
--- a/edge_auto_launch/launch/component/voxel_grid_based_euclidean_cluster.launch.xml
+++ b/edge_auto_launch/launch/component/voxel_grid_based_euclidean_cluster.launch.xml
@@ -5,7 +5,7 @@
 
   <group>
     <node_container pkg="rclcpp_components" exec="component_container" name="container" namespace="">
-      <composable_node pkg="euclidean_cluster" plugin="euclidean_cluster::VoxelGridBasedEuclideanClusterNode" name="euclidean_cluster" namespace="">
+      <composable_node pkg="autoware_euclidean_cluster" plugin="euclidean_cluster::VoxelGridBasedEuclideanClusterNode" name="euclidean_cluster" namespace="">
         <remap from="input" to="$(var input/pointcloud)"/>
         <remap from="output" to="$(var output/objects)"/>
         <param from="$(var param_path)"/>

--- a/edge_auto_launch/launch/component/voxel_grid_based_euclidean_cluster.launch.xml
+++ b/edge_auto_launch/launch/component/voxel_grid_based_euclidean_cluster.launch.xml
@@ -5,7 +5,7 @@
 
   <group>
     <node_container pkg="rclcpp_components" exec="component_container" name="container" namespace="">
-      <composable_node pkg="autoware_euclidean_cluster" plugin="euclidean_cluster::VoxelGridBasedEuclideanClusterNode" name="euclidean_cluster" namespace="">
+      <composable_node pkg="autoware_euclidean_cluster" plugin="autoware::euclidean_cluster::VoxelGridBasedEuclideanClusterNode" name="euclidean_cluster" namespace="">
         <remap from="input" to="$(var input/pointcloud)"/>
         <remap from="output" to="$(var output/objects)"/>
         <param from="$(var param_path)"/>

--- a/edge_auto_launch/package.xml
+++ b/edge_auto_launch/package.xml
@@ -12,7 +12,7 @@
 
   <exec_depend>autoware_auto_perception_rviz_plugin</exec_depend>
   <exec_depend>detected_object_feature_remover</exec_depend>
-  <exec_depend>euclidean_cluster</exec_depend>
+  <exec_depend>autoware_euclidean_cluster</exec_depend>
   <exec_depend>extrinsic_calibration_manager</exec_depend>
   <exec_depend>extrinsic_manual_calibrator</exec_depend>
   <exec_depend>extrinsic_tag_based_calibrator</exec_depend>


### PR DESCRIPTION
## Description
This PR adds the autoware_ prefix to the package name.

Changes are as following.
1. Package names in `CMakeLists.txt`, `package.xml`
2. Launch files `$(find-pkg-share ...)`

This PR do not contains any logic change.

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569
Releated PR: https://github.com/autowarefoundation/autoware.universe/pull/8003

## How was this PR tested?


## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.