### PR TITLE
refactor: add package name prefix of autoware_ for detected_object_feature_remover

### DIFF
--- a/edge_auto_launch/launch/perception_xt32_sample.launch.xml
+++ b/edge_auto_launch/launch/perception_xt32_sample.launch.xml
@@ -60,7 +60,7 @@
           <arg name="output/objects" value="objects_with_feature"/>
           <arg name="node_name" value="shape_estimation"/>
         </include>
-        <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
+        <include file="$(find-pkg-share autoware_detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
           <arg name="input" value="objects_with_feature"/>
           <arg name="output" value="/perception/object_recognition/detection/euclidean_cluster/objects"/>
           <arg name="node_name" value="detected_object_feature_remover"/>
@@ -83,7 +83,7 @@
         <arg name="output/objects" value="objects_with_feature"/>
         <arg name="node_name" value="shape_estimation"/>
       </include>
-      <include file="$(find-pkg-share detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
+      <include file="$(find-pkg-share autoware_detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
         <arg name="input" value="objects_with_feature"/>
         <arg name="output" value="/perception/object_recognition/detection/objects"/>
         <arg name="node_name" value="detected_object_feature_remover"/>

--- a/edge_auto_launch/package.xml
+++ b/edge_auto_launch/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>autoware_auto_perception_rviz_plugin</exec_depend>
-  <exec_depend>detected_object_feature_remover</exec_depend>
+  <exec_depend>autoware_detected_object_feature_remover</exec_depend>
   <exec_depend>autoware_euclidean_cluster</exec_depend>
   <exec_depend>extrinsic_calibration_manager</exec_depend>
   <exec_depend>extrinsic_manual_calibrator</exec_depend>


### PR DESCRIPTION
## Description
This PR adds the autoware_ prefix to the package name.
Related to PR: https://github.com/autowarefoundation/autoware.universe/pull/8127

Changes are as following.
1. Package names in `package.xml`
2. Launch files `$(find-pkg-share ...)`

This PR do not contains any logic change.

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569
## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.