### PR TITLE
refactor: add package name prefix of autoware_ for ground_segmentation

### DIFF
--- a/edge_auto_launch/launch/component/scan_ground_filter.launch.xml
+++ b/edge_auto_launch/launch/component/scan_ground_filter.launch.xml
@@ -6,7 +6,7 @@
   <group>
     <push-ros-namespace namespace="ground_segmentation"/>
     <node_container pkg="rclcpp_components" exec="component_container" name="container" namespace="">
-      <composable_node pkg="ground_segmentation" plugin="ground_segmentation::ScanGroundFilterComponent" name="ground_segmentation" namespace="">
+      <composable_node pkg="autoware_ground_segmentation" plugin="autoware::ground_segmentation::ScanGroundFilterComponent" name="ground_segmentation" namespace="">
         <remap from="input" to="$(var input/pointcloud)"/>
         <remap from="output" to="$(var output/pointcloud)"/>
         <param from="$(var param_path)"/>

--- a/edge_auto_launch/package.xml
+++ b/edge_auto_launch/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>extrinsic_calibration_manager</exec_depend>
   <exec_depend>extrinsic_manual_calibrator</exec_depend>
   <exec_depend>extrinsic_tag_based_calibrator</exec_depend>
-  <exec_depend>ground_segmentation</exec_depend>
+  <exec_depend>autoware_ground_segmentation</exec_depend>
   <exec_depend>intrinsic_camera_calibrator</exec_depend>
   <exec_depend>lidar_centerpoint</exec_depend>
   <exec_depend>nebula_sensor_driver</exec_depend>


### PR DESCRIPTION
## Description
- This PR adds the autoware_ prefix to the package name.
- Related to https://github.com/autowarefoundation/autoware.universe/pull/8135

Changes are as following.
1. Package names in `package.xml`
2. Launch files `$(find-pkg-share ...)`

This PR do not contains any logic change.

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## How was this PR tested?
Tested in a local recompute environment and the TIER IV Cloud environment.

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.